### PR TITLE
Update gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -213,7 +213,8 @@ gem 'github-pages-health-check', '1.16.1'
 #
 gem 'github-pages', '209'
 #
-# Note. The ''github-markdown' dependency is no longer designated at the online GitHub Pages dependency chart
+# Note. The `github-markdown` dependency is no longer designated
+# at the online GitHub Pages dependency chart
 # C=> https://pages.github.com/versions/
 # gem 'github-markdown'
 #


### PR DESCRIPTION
The `github-markdown` is no longer designated at `pages.github.com/versions`